### PR TITLE
Update the .nimble file to use nimscript, add `bin` key.

### DIFF
--- a/tnim.nim
+++ b/tnim.nim
@@ -37,7 +37,7 @@ import strutils, tables, os, osproc
 
 const
   TnimName     = "TNim"
-  TnimVersion  = 1.01
+  TnimVersion  = 1.02
   TnimStart    = "nim> "
   TnimContinue = ".... "   # add "..".repeat(n) before this
   SavedFileName = "tnim_dat.dat"

--- a/tnim.nimble
+++ b/tnim.nimble
@@ -1,9 +1,10 @@
-[Package]
-name: "tnim"
-version: "1.0.1"
-author: "James Parkinson"
-description: "Nim REPL - a sandbox for testing Nim code"
-license: "MIT"
+# Package
+version     = "1.0.2"
+author      = "James Parkinson"
+description = "Nim REPL - a sandbox for testing Nim code"
+license     = "MIT"
+bin         = @["tnim"]
 
-[Deps]
-requires: "nim >= 0.10.0"
+# Dependencies
+
+requires @["nim >= 0.10.0"]


### PR DESCRIPTION
Without `bin` key `nimble install tnim` would no longer install a functioning
binary. Updated to nimscript for fun.

I also bumped the version so it wouldn't conflict with existing installations. I can resubmit the PR without the version change if you like.
